### PR TITLE
Fix openssl error with CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,6 +29,9 @@ jobs:
           FILE_NAME: "openssl.cnf"
           FILE_BASE64: "W3Byb3ZpZGVyX3NlY3RdCmRlZmF1bHQgPSBkZWZhdWx0X3NlY3QKbGVnYWN5ID0gbGVnYWN5X3NlY3QKCltkZWZhdWx0X3NlY3RdCmFjdGl2YXRlID0gMQoKW2xlZ2FjeV9zZWN0XQphY3RpdmF0ZSA9IDEK"
 
+      - run: cat openssl.cnf
+      - run: pwd
+
       - run: yarn install
       - run: yarn build
       - run: yarn test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,8 +22,6 @@ jobs:
       OPENSSL_CONF: /tmp/openssl.cnf
 
     steps:
-      - uses: actions/checkout@v2
-
       - uses: DamianReeves/write-file-action@master
         with:
           path: /tmp/openssl.cnf
@@ -39,9 +37,9 @@ jobs:
             activate = 1
           write-mode: append
 
-      - run: cat /tmp/openssl.cnf
-      - run: pwd
-
+      - uses: actions/checkout@v2
       - run: yarn install
       - run: yarn build
+        env:
+          NODE_OPTONS: --openssl-legacy-provider
       - run: yarn test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,17 +19,17 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      OPENSSL_CONF: openssl.cnf
+      OPENSSL_CONF: /tmp/openssl.cnf
 
     steps:
       - uses: actions/checkout@v2
 
       - uses: "finnp/create-file-action@master"
         env:
-          FILE_NAME: "openssl.cnf"
+          FILE_NAME: "/tmp/openssl.cnf"
           FILE_BASE64: "W3Byb3ZpZGVyX3NlY3RdCmRlZmF1bHQgPSBkZWZhdWx0X3NlY3QKbGVnYWN5ID0gbGVnYWN5X3NlY3QKCltkZWZhdWx0X3NlY3RdCmFjdGl2YXRlID0gMQoKW2xlZ2FjeV9zZWN0XQphY3RpdmF0ZSA9IDEK"
 
-      - run: cat openssl.cnf
+      - run: cat /tmp/openssl.cnf
       - run: pwd
 
       - run: yarn install

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,25 +18,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    env:
-      OPENSSL_CONF: /tmp/openssl.cnf
-
     steps:
-      - uses: DamianReeves/write-file-action@master
-        with:
-          path: /tmp/openssl.cnf
-          contents: |
-            [provider_sect]
-            default = default_sect
-            legacy = legacy_sect
-
-            [default_sect]
-            activate = 1
-
-            [legacy_sect]
-            activate = 1
-          write-mode: append
-
       - uses: actions/checkout@v2
       - run: yarn install
       - run: yarn build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,6 +18,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      NODE_OPTIONS: --openssl-legacy-provider
+
     steps:
       - uses: actions/checkout@v2
       - run: yarn install

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -39,6 +39,8 @@ jobs:
 
       - uses: actions/checkout@v2
       - run: yarn install
+        env:
+          NODE_OPTONS: --openssl-legacy-provider
       - run: yarn build
         env:
           NODE_OPTONS: --openssl-legacy-provider

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,10 +24,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: "finnp/create-file-action@master"
-        env:
-          FILE_NAME: "/tmp/openssl.cnf"
-          FILE_BASE64: "W3Byb3ZpZGVyX3NlY3RdCmRlZmF1bHQgPSBkZWZhdWx0X3NlY3QKbGVnYWN5ID0gbGVnYWN5X3NlY3QKCltkZWZhdWx0X3NlY3RdCmFjdGl2YXRlID0gMQoKW2xlZ2FjeV9zZWN0XQphY3RpdmF0ZSA9IDEK"
+      - uses: DamianReeves/write-file-action@master
+        with:
+          path: /tmp/openssl.cnf
+          contents: |
+            [provider_sect]
+            default = default_sect
+            legacy = legacy_sect
+
+            [default_sect]
+            activate = 1
+
+            [legacy_sect]
+            activate = 1
+          write-mode: append
 
       - run: cat /tmp/openssl.cnf
       - run: pwd

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      NODE_OPTIONS: --openssl-legacy-provider
       OPENSSL_CONF: openssl.cnf
 
     steps:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -39,5 +39,7 @@ jobs:
 
       - uses: actions/checkout@v2
       - run: yarn install
-      - run: NODE_OPTIONS='--openssl-legacy-provider' yarn build
+      - run: yarn build
+        env:
+          NODE_OPTIONS: '--openssl-legacy-provider'
       - run: yarn test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -39,9 +39,5 @@ jobs:
 
       - uses: actions/checkout@v2
       - run: yarn install
-        env:
-          NODE_OPTONS: --openssl-legacy-provider
-      - run: yarn build
-        env:
-          NODE_OPTONS: --openssl-legacy-provider
+      - run: NODE_OPTIONS='--openssl-legacy-provider' yarn build
       - run: yarn test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,9 +20,16 @@ jobs:
 
     env:
       NODE_OPTIONS: --openssl-legacy-provider
+      OPENSSL_CONF: openssl.cnf
 
     steps:
       - uses: actions/checkout@v2
+
+      - uses: "finnp/create-file-action@master"
+        env:
+          FILE_NAME: "openssl.cnf"
+          FILE_BASE64: "W3Byb3ZpZGVyX3NlY3RdCmRlZmF1bHQgPSBkZWZhdWx0X3NlY3QKbGVnYWN5ID0gbGVnYWN5X3NlY3QKCltkZWZhdWx0X3NlY3RdCmFjdGl2YXRlID0gMQoKW2xlZ2FjeV9zZWN0XQphY3RpdmF0ZSA9IDEK"
+
       - run: yarn install
       - run: yarn build
       - run: yarn test


### PR DESCRIPTION
```
opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
[38](https://github.com/conradtchan/jobmon/actions/runs/4684110744/jobs/8299900501#step:4:39)
  library: 'digital envelope routines',
[39](https://github.com/conradtchan/jobmon/actions/runs/4684110744/jobs/8299900501#step:4:40)
  reason: 'unsupported',
[40](https://github.com/conradtchan/jobmon/actions/runs/4684110744/jobs/8299900501#step:4:41)
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
```

Solution is to use `--openssl-legacy-provider`

See: https://stackoverflow.com/questions/69665222/node-js-17-0-1-gatsby-error-digital-envelope-routinesunsupported-err-os