### PR TITLE
remove node from layout if the job is running but influx doesn't porting it as up

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,6 +15,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - run: yarn install
     - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,36 +2,35 @@
 
 repos:
   - repo: https://github.com/ambv/black
-    rev: 22.10.0
+    rev: 23.3.0
     hooks:
       - id: black
-        language_version: python3.7
         exclude: ^node_modules/
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.28.0
+    rev: v1.32.0
     hooks:
       - id: yamllint
         args: ['-d relaxed']
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.5
+    rev: 5.12.0
     hooks:
       - id: isort
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: 'v8.26.0'
+    rev: 'v8.43.0'
     hooks:
       - id: eslint
         args: ['--fix']

--- a/backend/backend_ozstar.py
+++ b/backend/backend_ozstar.py
@@ -698,6 +698,14 @@ class Backend(BackendBase):
 
         layout = copy.deepcopy(job["cpus_alloc_layout"])
 
+        # Remove node from layout if the job is running but influx doesn't report it as up
+        # This means that something is out of sync of the job has crashed
+        if self.job_state(job_id) == "RUNNING":
+            for node in list(layout.keys()):
+                if self.node_up(node) is False:
+                    self.log.warn(f"Removing node {node} from layout for job {job_id}")
+                    del layout[node]
+
         return layout
 
     def job_gpu_layout(self, job_id):

--- a/backend/backend_ozstar.py
+++ b/backend/backend_ozstar.py
@@ -199,7 +199,6 @@ class Backend(BackendBase):
             slurm_job_id = int(record["job"])
 
             if self.job_state(slurm_job_id=slurm_job_id) == "RUNNING":
-
                 # Convert to full ID
                 job_id = self.full_id[slurm_job_id]
 
@@ -214,7 +213,6 @@ class Backend(BackendBase):
                 mem_data[job_id]["mem"][node] = mem
 
         for job_id in mem_data:
-
             # Initialise max memory record
             if job_id not in self.mem_max:
                 self.mem_max[job_id] = 0
@@ -564,7 +562,6 @@ class Backend(BackendBase):
                     self.id_map[full_ids[-1]] = job_id
 
             else:
-
                 # Change the running job ID to a full ID
                 if (
                     job_entry["array_task_id"] is not None
@@ -835,7 +832,6 @@ class Backend(BackendBase):
         jobs_with_stats = []
 
         for table in influx_result:
-
             # Cycle loop if there are no records in this table
             if len(table.records) == 0:
                 continue
@@ -877,7 +873,6 @@ class Backend(BackendBase):
         lustre_per_node_data = {}
 
         for table in influx_result:
-
             # Cycle loop if there are no records in this table
             if len(table.records) == 0:
                 continue

--- a/backend/showbf.py
+++ b/backend/showbf.py
@@ -119,7 +119,6 @@ def jobs():
     j = {}
 
     for id, s in slurm_jobs.items():
-
         j[id] = {
             "nCpus": s["num_cpus"],
             "state": s["job_state"],


### PR DESCRIPTION
Fixes a rare bug if the job has recently crashed. Prevents the frontend from trying to read data from a crashed node.