### PR TITLE
Add support for nodes with 4 GPUs

### DIFF
--- a/frontend/src/NodeDetails.jsx
+++ b/frontend/src/NodeDetails.jsx
@@ -385,7 +385,10 @@ export default class NodeDetails extends React.Component {
           data={historyChart}
           dataKeys={gpuNames}
           colors={[
-            style.getPropertyValue("--piecolor-gpu"),
+            style.getPropertyValue("--piecolor-gpu-1"),
+            style.getPropertyValue("--piecolor-gpu-2"),
+            style.getPropertyValue("--piecolor-gpu-3"),
+            style.getPropertyValue("--piecolor-gpu-4"),
           ]}
           lineStyle={[
             "fill",

--- a/frontend/src/NodeOverview.jsx
+++ b/frontend/src/NodeOverview.jsx
@@ -329,7 +329,7 @@ export default class NodeOverview extends React.Component {
           data={historyChart}
           dataKeys={["gpu"]}
           colors={[
-            style.getPropertyValue("--piecolor-gpu"),
+            style.getPropertyValue("--piecolor-gpu-1"),
           ]}
           lineStyle={[
             "fill",

--- a/frontend/src/NodePie.jsx
+++ b/frontend/src/NodePie.jsx
@@ -42,7 +42,7 @@ export default class NodePie extends React.PureComponent {
 
     const gpuColors = [
       style.getPropertyValue("--piecolor-blank"),
-      style.getPropertyValue("--piecolor-gpu"),
+      style.getPropertyValue("--piecolor-gpu-1"),
     ];
 
     const data = {

--- a/frontend/src/colours.css
+++ b/frontend/src/colours.css
@@ -27,7 +27,10 @@
     --piecolor-nice: #ccc;
     --piecolor-mem: #e5b81f;
     --piecolor-disk: #3a2cc2;
-    --piecolor-gpu: #9a3fc2;
+    --piecolor-gpu-1: #9a3fc2;
+    --piecolor-gpu-2: #d93bad;
+    --piecolor-gpu-3: #cf3c38;
+    --piecolor-gpu-4: #5531c3;
 
     /* Pie cycle colors */
     --piecycle-1: #0088fe;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -590,7 +590,7 @@ div:focus {outline: 0px;}
 }
 
 .circle.gpu {
-  background: var(--piecolor-gpu);
+  background: var(--piecolor-gpu-1);
 }
 
 .switch-parent {


### PR DESCRIPTION
Additional colours for GPU graphs to distinguish between GPUs. Previously only supported 2 GPUs, now supports 4.