### PR TITLE
Bugfix: frontend crashing when gpu data is not loaded yet

### DIFF
--- a/frontend/src/NodeDetails.jsx
+++ b/frontend/src/NodeDetails.jsx
@@ -589,7 +589,7 @@ export default class NodeDetails extends React.Component {
     );
 
     // Display a per-job GPU total if there are GPUs in this job
-    if (historyChart[0].job_gpu >= 0) {
+    if (historyChart.length > 0 && historyChart[0].job_gpu >= 0) {
       charts.push(
         <PropChart
           key="job_gpu"


### PR DESCRIPTION
There is a check for the presence of GPU data, but this fails when no snapshots have been loaded yet.

A check for the array length fixes this.