### PR TITLE
Handle edge case with slurm job arrays

### DIFF
--- a/backend/backend_ozstar.py
+++ b/backend/backend_ozstar.py
@@ -656,8 +656,16 @@ class Backend(BackendBase):
                 if ss[1] == "...":
                     c.append(int(ss[0]))
                 else:
+                    start = ss[0]
+                    end = ss[1]
+                    if "..." in end:
+                        if end.strip("...") > start:
+                            end = end.strip("...")
+                        else:
+                            # Just append the first number
+                            end = start
                     # Range may be followed by "...", but is still complete
-                    for j in range(int(ss[0]), int(ss[1].strip("...")) + 1):
+                    for j in range(int(start), int(end) + 1):
                         c.append(j)
             else:
                 if "..." in i:

--- a/backend/backend_ozstar.py
+++ b/backend/backend_ozstar.py
@@ -656,7 +656,8 @@ class Backend(BackendBase):
                 if ss[1] == "...":
                     c.append(int(ss[0]))
                 else:
-                    for j in range(int(ss[0]), int(ss[1]) + 1):
+                    # Range may be followed by "...", but is still complete
+                    for j in range(int(ss[0]), int(ss[1].strip("...")) + 1):
                         c.append(j)
             else:
                 if "..." in i:


### PR DESCRIPTION
A job array followed by ... may not be handled correctly if it does not have a comma.

For example,
```
148-150,...
```
is OK, but
```
148-15...
```
resulted in an integer conversion error.

This is fixed by always discarding the last item if `...` is present and the second number is smaller than the first.