### PR TITLE
Bugfix: GPU layout on OzSTAR

### DIFF
--- a/backend/backend_ozstar.py
+++ b/backend/backend_ozstar.py
@@ -774,6 +774,15 @@ class Backend(BackendBase):
                     )
                     layout = self.scontrol_gpu(job_id)
 
+                    # Make sure each item in the GPU layout is also in the CPU layout
+                    # This is in case scontrol returns an incorrect value
+                    for node in layout:
+                        if node not in self.job_layout(job_id):
+                            self.log.warn(
+                                f"Node {node} in GPU layout for job {job_id} not in CPU layout"
+                            )
+                            del layout[node]
+
                 # Minimise the number of scontrol calls by caching the results
                 # - Assume that GPU affinity is fixed for the lifetime of the job
                 # - scontrol should only be called once per job

--- a/frontend/src/warnings.js
+++ b/frontend/src/warnings.js
@@ -123,21 +123,26 @@ export function instantWarnings(data) {
 
         for (let k = 0; k < gpuNodeNames.length; k += 1) {
           const gpuNodeName = gpuNodeNames[k];
-          for (let j = 0; j < job.gpuLayout[gpuNodeName].length; j += 1) {
-            // Sometimes the GPU stats are missing and .gpus is null
-            if (data.nodes[gpuNodeName].gpus !== null) {
-              const gpuIndex = job.gpuLayout[gpuNodeName][j];
-              nGpus += 1;
-              gpuPercent += data.nodes[gpuNodeName].gpus["gpu".concat(gpuIndex.toString())];
+
+          // If this job is not running on this node, there has been a mistake in the backend
+          // Skip this node
+          if (jobNodeNames.includes(gpuNodeName)) {
+            for (let j = 0; j < job.gpuLayout[gpuNodeName].length; j += 1) {
+              // Sometimes the GPU stats are missing and .gpus is null
+              if (data.nodes[gpuNodeName].gpus !== null) {
+                const gpuIndex = job.gpuLayout[gpuNodeName][j];
+                nGpus += 1;
+                gpuPercent += data.nodes[gpuNodeName].gpus["gpu".concat(gpuIndex.toString())];
+              }
             }
-          }
 
-          gpuPercent /= nGpus;
+            gpuPercent /= nGpus;
 
-          // If below utilisation
-          if (gpuPercent < config.warnGpuUtil) {
-            // Score = percentage wasted
-            warnings[gpuNodeName].jobs[jobId].gpuUtil = config.warnGpuUtil - gpuPercent;
+            // If below utilisation
+            if (gpuPercent < config.warnGpuUtil) {
+              // Score = percentage wasted
+              warnings[gpuNodeName].jobs[jobId].gpuUtil = config.warnGpuUtil - gpuPercent;
+            }
           }
         }
       }


### PR DESCRIPTION
Ensure that the GPU layout of a job is consistent with the CPU layout. Discard nodes in the GPU layout that are not present in the CPU layout. Also catch this error to prevent a frontend crash.