### PR TITLE
fix: update regex to match GRES format correctly

### DIFF
--- a/backend/backend_ozstar.py
+++ b/backend/backend_ozstar.py
@@ -832,7 +832,7 @@ class Backend(BackendBase):
 
                 match = re.search(
                     f"Nodes={host_base}.*{host_number}"
-                    + r".*GRES=gpu:.*\d\(IDX:(.{1,3})\)",
+                    + r".*GRES=.*gpu:.*\d\(IDX:(.{1,3})\)",
                     output,
                 )
                 if match is not None:


### PR DESCRIPTION
This pull request addresses an issue with the regular expression used to match the Generic Resource (GRES) format. The previous implementation did not account for the possibility of other resources being listed before the GPU, which could lead to incorrect parsing.