### PR TITLE
fix expensive query to gather hostnames from influxdb

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,4 +17,4 @@ jobs:
       with:
         python-version: '3.8'
     - run: yarn install
-    - uses: pre-commit/action@v2.0.0
+    - uses: pre-commit/action@v3.0.1

--- a/backend/backend_ozstar.py
+++ b/backend/backend_ozstar.py
@@ -569,8 +569,10 @@ class Backend(BackendBase):
         return 0
 
     def hostnames(self):
+        # Filter to 1h and mem only to avoid an expensive query
         query = f'import "influxdata/influxdb/schema"\
-            schema.tagValues(bucket:"{influx_config.BUCKET_TELEGRAF}", tag:"host")\
+            schema.tagValues(bucket:"{influx_config.BUCKET_TELEGRAF}",\
+            tag:"host", start: -1h, predicate: (r) => r._measurement == "mem",)\
             |> sort()'
         result = self.query_influx(query)
         table = result[0]


### PR DESCRIPTION
This pull request includes a small optimization to the `hostnames` method in `backend/backend_ozstar.py`. The change modifies the InfluxDB query to filter data for the last hour and limit it to the "mem" measurement, reducing the cost of the query.