### PR TITLE
create a new instance of the influxdb query api for each call

### DIFF
--- a/backend/backend_ozstar.py
+++ b/backend/backend_ozstar.py
@@ -24,7 +24,6 @@ class Backend(BackendBase):
             token=influx_config.TOKEN,
             timeout="30s",
         )
-        self.influx_query_api = self.influx_client.query_api()
 
         # Dict of username mappings
         self.usernames = {}
@@ -262,7 +261,10 @@ class Backend(BackendBase):
         self.log.info(f"Loaded {len(mem_max)} max memory usage records from influxdb")
 
     def query_influx(self, query):
-        return self.influx_query_api.query(query=query, org=influx_config.ORG)
+        query_api = self.influx_client.query_api()
+        result = query_api.query(query=query, org=influx_config.ORG)
+        del query_api
+        return result
 
     def query_influx_memory(self):
         self.log.info("Querying Influx: memory")


### PR DESCRIPTION
This pull request modifies how the InfluxDB query API is used in the `backend/backend_ozstar.py` file, aiming to improve resource management by creating and disposing of the query API client within the scope of each query rather than maintaining a persistent instance.