### PR TITLE
Use Jobs() API from pyslurm 24.11

### DIFF
--- a/backend/jobmon.service
+++ b/backend/jobmon.service
@@ -8,7 +8,7 @@ User=jobmon
 WorkingDirectory=/opt/jobmon
 ExecStart=/usr/bin/python3 jobmon.py
 Restart=on-failure
-Environment=PYTHONPATH=/apps/influxdb-client/1.44.0/lib64/python3.9/site-packages:/apps/pyslurm/23.11.x-20240803-py3/lib64/python3.9/site-packages/pyslurm-23.11.0-py3.9-linux-x86_64.egg
+Environment=PYTHONPATH=/apps/influxdb-client/1.44.0/lib64/python3.9/site-packages:/apps/pyslurm/24.11.x-20250703/lib64/python3.9/site-packages/pyslurm-24.11.0-py3.9-linux-x86_64.egg
 
 [Install]
 WantedBy=multi-user.target

--- a/backend/showbf.py
+++ b/backend/showbf.py
@@ -122,7 +122,17 @@ def jobs():
     j = {}
     for job_id in jobs_api:
         job = jobs_api[job_id]
-        s = job.to_dict()
+        try:
+            s = job.to_dict()
+        except OverflowError:
+            # Handle overflow by extracting only the fields we need
+            s = {
+                "cpus": getattr(job, "cpus", 0),
+                "state": getattr(job, "state", None),
+                "time_limit": getattr(job, "time_limit", None),
+                "scheduled_nodes": getattr(job, "scheduled_nodes", None),
+                "start_time": getattr(job, "start_time", 0),
+            }
         # Convert new API layout dict to old list-of-ints format
         raw_layout = job.get_resource_layout_per_node()
         layout = {}

--- a/backend/showbf.py
+++ b/backend/showbf.py
@@ -122,30 +122,19 @@ def jobs():
     j = {}
     for job_id in jobs_api:
         job = jobs_api[job_id]
-        try:
-            s = job.to_dict()
-        except OverflowError:
-            # Handle overflow by extracting only the fields we need
-            s = {
-                "cpus": getattr(job, "cpus", 0),
-                "state": getattr(job, "state", None),
-                "time_limit": getattr(job, "time_limit", None),
-                "scheduled_nodes": getattr(job, "scheduled_nodes", None),
-                "start_time": getattr(job, "start_time", 0),
-            }
-        # Convert new API layout dict to old list-of-ints format
+        # Extract only the fields we need
         raw_layout = job.get_resource_layout_per_node()
         layout = {}
         for host, info in raw_layout.items():
             cpu_ids_str = info.get("cpu_ids", "")
             layout[host] = parseCpuList(cpu_ids_str)
         j[job_id] = {
-            "nCpus": s.get("cpus", 0),
-            "state": s.get("state"),
+            "nCpus": getattr(job, "cpus", 0),
+            "state": getattr(job, "state", None),
             "layout": layout,
-            "timeLimit": s.get("time_limit"),  # minutes
-            "schedNodes": s.get("scheduled_nodes"),
-            "startTime": s.get("start_time"),  # 0 or seconds
+            "timeLimit": getattr(job, "time_limit", None),  # minutes
+            "schedNodes": getattr(job, "scheduled_nodes", None),
+            "startTime": getattr(job, "start_time", 0),  # 0 or seconds
         }
         # Count GPUs via layout's gres info
         gpu_count = 0

--- a/backend/showbf.py
+++ b/backend/showbf.py
@@ -114,39 +114,42 @@ def nodes():
 
 
 def jobs():
-    slurm_jobs = pyslurm.job().get()
-
+    """
+    Retrieve jobs using the new pyslurm.Jobs API.
+    """
+    jobs_api = pyslurm.Jobs.load()
+    jobs_api.load_steps()
     j = {}
-
-    for id, s in slurm_jobs.items():
-        j[id] = {
-            "nCpus": s["num_cpus"],
-            "state": s["job_state"],
-            "layout": s["cpus_alloc_layout"],
-            "timeLimit": s["time_limit"],  # minutes
-            # pyslurm 18
-            "schedNodes": s["sched_nodes"],  # None or eg. bryan[1-4,6-8],john[1-3]
-            "startTime": s["start_time"],  # 0 or seconds
+    for job_id in jobs_api:
+        job = jobs_api[job_id]
+        s = job.to_dict()
+        # Convert new API layout dict to old list-of-ints format
+        raw_layout = job.get_resource_layout_per_node()
+        layout = {}
+        for host, info in raw_layout.items():
+            cpu_ids_str = info.get("cpu_ids", "")
+            layout[host] = parseCpuList(cpu_ids_str)
+        j[job_id] = {
+            "nCpus": s.get("cpus", 0),
+            "state": s.get("state"),
+            "layout": layout,
+            "timeLimit": s.get("time_limit"),  # minutes
+            "schedNodes": s.get("scheduled_nodes"),
+            "startTime": s.get("start_time"),  # 0 or seconds
         }
-
-        j[id]["nGpus"] = 0
-        # pyslurm 17
-        # for gres in s['gres']:
-        # pyslurm 18
-        if s["tres_per_node"] is not None:
-            for gres in s["tres_per_node"].split(","):
-                g = gres.split(":")
-                # print(id, gres, g, g[-1])
-                if g[0] == "gpu":  # eg. gpu:p100:2  gpu:2  gpu
-                    try:
-                        j[id]["nGpus"] += int(g[-1])
-                    except ValueError:
-                        j[id]["nGpus"] += 1
-
-        if debug:
-            if j[id]["startTime"] != 0 and j[id]["schedNodes"] is not None:
-                print(id, j[id])
-
+        # Count GPUs via layout's gres info
+        gpu_count = 0
+        for info in raw_layout.values():
+            for tres_name, tres_info in info.get("gres", {}).items():
+                if tres_name.startswith("gpu"):
+                    gpu_count += tres_info.get("count", 0)
+        j[job_id]["nGpus"] = gpu_count
+        if (
+            debug
+            and j[job_id]["startTime"] != 0
+            and j[job_id]["schedNodes"] is not None
+        ):
+            print(job_id, j[job_id])
     return j
 
 
@@ -459,11 +462,11 @@ def get_core_usage(data):
                                         "+",
                                         s1,
                                         "!=",
-                                        node["nCpuCores"],
+                                        node["nCpus"],
                                         "node",
                                         node,
                                     )
-                                if g0 + g1 != node["nGpuCores"]:
+                                if g0 + g1 != node["nGpus"]:
                                     print(
                                         hostname,
                                         "err: gpu: ",
@@ -471,7 +474,7 @@ def get_core_usage(data):
                                         "+",
                                         g1,
                                         "!=",
-                                        node["nGpuCores"],
+                                        node["nGpus"],
                                         "node",
                                         node,
                                     )


### PR DESCRIPTION
This PR updates to the `backend` codebase to improve compatibility with the new `pyslurm` API. CPU layouts have been dropped from the `job()` API and now have to be obtained from the newer `Job()` API. This new API also contains the GPU layout, so it no longer needs to be manually read from `scontrol`. This allows the methods used to cache the results of `scontrol` to be removed.

Also updated to use slurm's max memory value passed through the `VMSize` variable, instead of tracking it within jobmon.
