### PR TITLE
Fix graph pending jobs

### DIFF
--- a/frontend/src/NodeDetails.jsx
+++ b/frontend/src/NodeDetails.jsx
@@ -18,6 +18,362 @@ function idCopy(id) {
 export default class NodeDetails extends React.Component {
   static whyDidYouRender = true
 
+  static getJobPropCharts(historyChart) {
+    const style = getComputedStyle(document.documentElement);
+
+    const charts = [];
+
+    charts.push(
+      <PropChart
+        key="cpu"
+        name="CPU"
+        data={historyChart}
+        dataKeys={["job_user", "job_system", "job_wait"]}
+        colors={[
+          style.getPropertyValue("--piecolor-user"),
+          style.getPropertyValue("--piecolor-system"),
+          style.getPropertyValue("--piecolor-wait"),
+        ]}
+        lineStyle={[
+          "fill",
+          "fill",
+        ]}
+        unit="%"
+        dataMax={100}
+        stacked
+      />,
+    );
+
+    charts.push(
+      <PropChart
+        key="mem"
+        name="Memory"
+        data={historyChart}
+        dataKeys={["job_mem", "job_mem_max", "job_mem_requested"]}
+        colors={[
+          style.getPropertyValue("--piecolor-mem"),
+          style.getPropertyValue("--piecolor-mem"),
+          style.getPropertyValue("--piecolor-mem"),
+        ]}
+        lineStyle={[
+          "fill",
+          "line",
+          "dashed",
+        ]}
+        unit="B"
+        stacked={false}
+      />,
+    );
+
+    charts.push(
+      <PropChart
+        key="job_lustre_read"
+        name="Lustre read"
+        data={historyChart}
+        dataKeys={["fred_read", "home_read", "apps_read", "images_read"]}
+        colors={[
+          style.getPropertyValue("--piecycle-1"),
+          style.getPropertyValue("--piecycle-2"),
+          style.getPropertyValue("--piecycle-3"),
+          style.getPropertyValue("--piecycle-4"),
+        ]}
+        lineStyle={[
+          "fill",
+          "fill",
+          "fill",
+          "fill",
+        ]}
+        unit="B/s"
+        stacked
+      />,
+    );
+
+    charts.push(
+      <PropChart
+        key="job_lustre_write"
+        name="Lustre write"
+        data={historyChart}
+        dataKeys={["fred_write", "home_write"]}
+        colors={[
+          style.getPropertyValue("--piecycle-1"),
+          style.getPropertyValue("--piecycle-2"),
+        ]}
+        lineStyle={[
+          "fill",
+          "fill",
+        ]}
+        unit="B/s"
+        stacked
+      />,
+    );
+
+    charts.push(
+      <PropChart
+        key="job_lustre_iops"
+        name="Lustre IOPS"
+        data={historyChart}
+        dataKeys={["fred_iops", "home_iops", "apps_iops", "images_iops"]}
+        colors={[
+          style.getPropertyValue("--piecycle-1"),
+          style.getPropertyValue("--piecycle-2"),
+          style.getPropertyValue("--piecycle-3"),
+          style.getPropertyValue("--piecycle-4"),
+        ]}
+        lineStyle={[
+          "fill",
+          "fill",
+          "fill",
+          "fill",
+        ]}
+        unit="/s"
+        stacked
+      />,
+    );
+
+    charts.push(
+      <PropChart
+        key="jobfs"
+        name="JOBFS usage"
+        data={historyChart}
+        dataKeys={["jobfs_used", "jobfs_requested"]}
+        colors={[
+          style.getPropertyValue("--piecycle-4"),
+          style.getPropertyValue("--piecycle-4"),
+        ]}
+        lineStyle={[
+          "fill",
+          "dashed",
+        ]}
+        unit="B"
+        stacked
+      />,
+    );
+
+    // Display a per-job GPU total if there are GPUs in this job
+    if (historyChart.length > 0 && historyChart[0].job_gpu >= 0) {
+      charts.push(
+        <PropChart
+          key="job_gpu"
+          name="GPU Utilization"
+          data={historyChart}
+          dataKeys={["job_gpu"]}
+          colors={[
+            style.getPropertyValue("--piecolor-gpu-1"),
+          ]}
+          lineStyle={[
+            "fill",
+          ]}
+          unit="%"
+          dataMax={100}
+          stacked
+        />,
+      );
+
+      // Display a per-job GPU memory usage if available
+      if (historyChart.length > 0 && historyChart[0].job_gpu_mem_total > 0) {
+        charts.push(
+          <PropChart
+            key="job_gpu_mem"
+            name="GPU Memory"
+            data={historyChart}
+            dataKeys={["job_gpu_mem"]}
+            colors={[
+              style.getPropertyValue("--piecolor-gpu-2"),
+            ]}
+            lineStyle={[
+              "fill",
+            ]}
+            unit="B"
+            dataMax={(historyChart[0].job_gpu_mem_total > 0)
+              ? historyChart[0].job_gpu_mem_total
+              : "dataMax"}
+            stacked={false}
+          />,
+        );
+      }
+    }
+
+    return (
+      <div className="prop-charts">
+        {charts}
+      </div>
+    );
+  }
+
+  static initializeJobMetrics() {
+    return {
+      jobMem: 0.0,
+      jobMemMax: 0.0,
+      jobMemRequested: 0.0,
+      jobUser: 0.0,
+      jobSystem: 0.0,
+      jobWait: 0.0,
+      jobGpu: -1.0,
+      jobGpuMem: 0.0,
+      jobGpuMemTotal: 0.0,
+      jobfs: 0.0,
+      jobfsRequested: 0.0,
+      fredOssRead: 0.0,
+      fredOssWrite: 0.0,
+      fredMdsIops: 0.0,
+      homeOssRead: 0.0,
+      homeOssWrite: 0.0,
+      homeMdsIops: 0.0,
+      appsOssRead: 0.0,
+      appsMdsIops: 0.0,
+      imagesOssRead: 0.0,
+      imagesMdsIops: 0.0,
+    };
+  }
+
+  static extractJobUsageMetrics(job, usage, name) {
+    const metrics = {
+      jobUser: usage.cpu.user,
+      jobSystem: usage.cpu.system,
+      jobWait: usage.cpu.wait,
+      jobfs: usage.jobfs.used,
+      jobfsRequested: job.jobfsReq,
+      jobMem: 0.0,
+      jobMemMax: 0.0,
+      jobMemRequested: 0.0,
+      jobGpu: -1.0,
+      jobGpuMem: 0.0,
+      jobGpuMemTotal: 0.0,
+    };
+
+    // Memory usage
+    if (Object.prototype.hasOwnProperty.call(job.mem, name)) {
+      metrics.jobMem = usage.mem.used;
+      metrics.jobMemMax = usage.mem.max;
+      metrics.jobMemRequested = job.memReq;
+    }
+
+    // GPU usage
+    if (job.nGpus > 0) {
+      metrics.jobGpu = usage.gpu.total;
+      if (usage.gpu.memory && usage.gpu.memory.total > 0) {
+        metrics.jobGpuMem = usage.gpu.memory.used;
+        metrics.jobGpuMemTotal = usage.gpu.memory.total;
+      }
+    }
+
+    return metrics;
+  }
+
+  static extractLustreMetrics(jobLustre) {
+    const metrics = {
+      fredOssRead: 0.0,
+      fredOssWrite: 0.0,
+      fredMdsIops: 0.0,
+      homeOssRead: 0.0,
+      homeOssWrite: 0.0,
+      homeMdsIops: 0.0,
+      appsOssRead: 0.0,
+      appsMdsIops: 0.0,
+      imagesOssRead: 0.0,
+      imagesMdsIops: 0.0,
+    };
+
+    if (Object.prototype.hasOwnProperty.call(jobLustre, "dagg")) {
+      metrics.fredOssRead = jobLustre.dagg.oss.read_bytes;
+      metrics.fredOssWrite = jobLustre.dagg.oss.write_bytes;
+      metrics.fredMdsIops = jobLustre.dagg.mds.iops;
+    }
+    if (Object.prototype.hasOwnProperty.call(jobLustre, "apps")) {
+      metrics.appsOssRead = jobLustre.apps.oss.read_bytes;
+      metrics.appsMdsIops = jobLustre.apps.mds.iops;
+    }
+    if (Object.prototype.hasOwnProperty.call(jobLustre, "images")) {
+      metrics.imagesOssRead = jobLustre.images.oss.read_bytes;
+      metrics.imagesMdsIops = jobLustre.images.mds.iops;
+    }
+    if (Object.prototype.hasOwnProperty.call(jobLustre, "home")) {
+      metrics.homeOssRead = jobLustre.home.oss.read_bytes;
+      metrics.homeOssWrite = jobLustre.home.oss.write_bytes;
+      metrics.homeMdsIops = jobLustre.home.mds.iops;
+    }
+
+    return metrics;
+  }
+
+  static createChartDataPoint(data, nodeData, jobMetrics) {
+    const d = new Date(data.timestamp * 1000);
+
+    return {
+      time: data.timestamp,
+      timeString: `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`,
+      user: nodeData.cpu.total[config.cpuKeys.user] + nodeData.cpu.total[config.cpuKeys.nice],
+      system: nodeData.cpu.total[config.cpuKeys.system],
+      wait: nodeData.cpu.total[config.cpuKeys.wait],
+      mem: nodeData.mem.used * constants.mb,
+      job_user: jobMetrics.jobUser,
+      job_system: jobMetrics.jobSystem,
+      job_wait: jobMetrics.jobWait,
+      job_mem: jobMetrics.jobMem * constants.mb,
+      job_mem_max: jobMetrics.jobMemMax * constants.mb,
+      job_mem_requested: jobMetrics.jobMemRequested * constants.mb,
+      job_gpu: jobMetrics.jobGpu,
+      job_gpu_mem: jobMetrics.jobGpuMem * constants.mb,
+      job_gpu_mem_total: jobMetrics.jobGpuMemTotal * constants.mb,
+      swap: (nodeData.swap.total - nodeData.swap.free) * constants.mb,
+      fred_read: jobMetrics.fredOssRead,
+      fred_write: jobMetrics.fredOssWrite,
+      fred_iops: jobMetrics.fredMdsIops,
+      home_read: jobMetrics.homeOssRead,
+      home_write: jobMetrics.homeOssWrite,
+      home_iops: jobMetrics.homeMdsIops,
+      apps_read: jobMetrics.appsOssRead,
+      apps_iops: jobMetrics.appsMdsIops,
+      images_read: jobMetrics.imagesOssRead,
+      images_iops: jobMetrics.imagesMdsIops,
+      jobfs_used: jobMetrics.jobfs * constants.mb,
+      jobfs_requested: jobMetrics.jobfsRequested * constants.mb,
+    };
+  }
+
+  static addOptionalDataToPoint(dataPoint, nodeData) {
+    const point = { ...dataPoint };
+
+    if (nodeData.infiniband !== null) {
+      point.infiniband_in = nodeData.infiniband.bytes_in;
+      point.infiniband_out = nodeData.infiniband.bytes_out;
+      point.infiniband_pkts_in = nodeData.infiniband.pkts_in;
+      point.infiniband_pkts_out = nodeData.infiniband.pkts_out;
+    }
+
+    if (nodeData.lustre !== null) {
+      point.lustre_read = nodeData.lustre.read;
+      point.lustre_write = nodeData.lustre.write;
+    }
+
+    if (nodeData.jobfs !== null) {
+      point.jobfs_read = nodeData.jobfs.read;
+      point.jobfs_write = nodeData.jobfs.write;
+    }
+
+    // Add GPU data
+    Array.from({ length: nodeData.nGpus }, (_, gpuIndex) => {
+      const gpuName = `gpu${gpuIndex.toString()}`;
+      const gpuMemName = `${gpuName}_mem`;
+
+      if (nodeData.gpus && gpuName in nodeData.gpus) {
+        point[gpuName] = nodeData.gpus[gpuName].util;
+
+        if (nodeData.gpus[gpuName].memory) {
+          const memTotal = nodeData.gpus[gpuName].memory.total;
+          const memUsed = nodeData.gpus[gpuName].memory.used;
+          if (memTotal > 0) {
+            point[gpuMemName] = memUsed * constants.mb;
+            point[`${gpuMemName}_total`] = memTotal * constants.mb;
+          }
+        }
+      }
+      return null;
+    });
+
+    return point;
+  }
+
   shouldComponentUpdate(nextProps) {
     const {
       name,
@@ -183,192 +539,55 @@ export default class NodeDetails extends React.Component {
   }
 
   getHistoryChart() {
-    const {
-      name,
-      selectedJobId,
-      historyData,
-    } = this.props;
+    const { name, selectedJobId, historyData } = this.props;
+
+    // Sort history data by timestamp
+    const sortedHistory = [...historyData].sort((a, b) => a.timestamp - b.timestamp);
+
     const historyChart = [];
 
-    const sortedHistory = historyData;
-    sortedHistory.sort(
-      (a, b) => {
-        if (a.timestamp < b.timestamp) {
-          return -1;
-        }
-        if (a.timestamp > b.timestamp) {
-          return 1;
-        } return 0;
-      },
-    );
-
-    for (let i = 0; i < sortedHistory.length; i += 1) {
-      const data = sortedHistory[i];
+    sortedHistory.forEach((data) => {
       const nodeData = data.nodes[name];
 
-      let jobMem = 0.0;
-      let jobMemMax = 0.0;
-      let jobMemRequested = 0.0;
+      // Initialize default metrics
+      let jobMetrics = NodeDetails.initializeJobMetrics();
 
-      let jobUser = 0.0;
-      let jobSystem = 0.0;
-      let jobWait = 0.0;
-
-      let jobGpu = -1.0; // -1 means no GPU
-      let jobGpuMem = 0.0; // GPU memory used by job
-      let jobGpuMemTotal = 0.0; // Total GPU memory available
-
-      let fredOssRead = 0.0;
-      let fredOssWrite = 0.0;
-      let fredMdsIops = 0.0;
-      let homeOssRead = 0.0;
-      let homeOssWrite = 0.0;
-      let homeMdsIops = 0.0;
-      let appsOssRead = 0.0;
-      let appsMdsIops = 0.0;
-      let imagesOssRead = 0.0;
-      let imagesMdsIops = 0.0;
-
-      let jobfs = 0.0;
-      let jobfsRequested = 0.0;
-
-      // Only if the job has started running
+      // Extract job metrics if job is running
       if (Object.prototype.hasOwnProperty.call(data.jobs, selectedJobId)) {
         const job = data.jobs[selectedJobId];
 
         // Skip this data point if the job is not in RUNNING state
         if (job.state !== "RUNNING") {
-          // eslint-disable-next-line no-continue
-          continue;
+          return; // Use return instead of continue for forEach
         }
 
         const usage = getNodeUsage(selectedJobId, job, nodeData, name);
 
-        // Memory usage
-        if (Object.prototype.hasOwnProperty.call(job.mem, name)) {
-          jobMem = usage.mem.used;
-          jobMemMax = usage.mem.max;
-          jobMemRequested = job.memReq;
+        // Extract basic job usage metrics
+        const basicMetrics = NodeDetails.extractJobUsageMetrics(job, usage, name);
+
+        // Extract Lustre metrics if available
+        let lustreMetrics = {};
+        if (Object.keys(job.lustre).length > 0) {
+          lustreMetrics = NodeDetails.extractLustreMetrics(job.lustre);
         }
 
-        // CPU usage
-        jobUser = usage.cpu.user;
-        jobSystem = usage.cpu.system;
-        jobWait = usage.cpu.wait;
-
-        // JOBFS usage
-        jobfs = usage.jobfs.used;
-        jobfsRequested = job.jobfsReq;
-
-        // Lustre job stats
-        if (Object.keys(data.jobs[selectedJobId].lustre).length > 0) {
-          const jobLustre = data.jobs[selectedJobId].lustre;
-
-          if (Object.prototype.hasOwnProperty.call(jobLustre, "dagg")) {
-            fredOssRead = jobLustre.dagg.oss.read_bytes;
-            fredOssWrite = jobLustre.dagg.oss.write_bytes;
-            fredMdsIops = jobLustre.dagg.mds.iops;
-          }
-          if (Object.prototype.hasOwnProperty.call(jobLustre, "apps")) {
-            appsOssRead = jobLustre.apps.oss.read_bytes;
-            appsMdsIops = jobLustre.apps.mds.iops;
-          }
-          if (Object.prototype.hasOwnProperty.call(jobLustre, "images")) {
-            imagesOssRead = jobLustre.images.oss.read_bytes;
-            imagesMdsIops = jobLustre.images.mds.iops;
-          }
-          if (Object.prototype.hasOwnProperty.call(jobLustre, "home")) {
-            homeOssRead = jobLustre.home.oss.read_bytes;
-            homeOssWrite = jobLustre.home.oss.write_bytes;
-            homeMdsIops = jobLustre.home.mds.iops;
-          }
-        }
-
-        // GPU usage
-        if (job.nGpus > 0) {
-          jobGpu = usage.gpu.total;
-
-          // GPU memory usage
-          if (usage.gpu.memory && usage.gpu.memory.total > 0) {
-            jobGpuMem = usage.gpu.memory.used;
-            jobGpuMemTotal = usage.gpu.memory.total;
-          }
-        }
+        // Combine all metrics
+        jobMetrics = {
+          ...basicMetrics,
+          ...lustreMetrics,
+        };
       }
 
-      const d = new Date(data.timestamp * 1000);
-      const x = {
-        time: data.timestamp,
-        timeString: `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`,
-        user: nodeData.cpu.total[config.cpuKeys.user] + nodeData.cpu.total[config.cpuKeys.nice],
-        system: nodeData.cpu.total[config.cpuKeys.system],
-        wait: nodeData.cpu.total[config.cpuKeys.wait],
-        mem: nodeData.mem.used * constants.mb,
-        job_user: jobUser,
-        job_system: jobSystem,
-        job_wait: jobWait,
-        job_mem: jobMem * constants.mb,
-        job_mem_max: jobMemMax * constants.mb,
-        job_mem_requested: jobMemRequested * constants.mb,
-        job_gpu: jobGpu,
-        job_gpu_mem: jobGpuMem * constants.mb,
-        job_gpu_mem_total: jobGpuMemTotal * constants.mb,
-        swap: (nodeData.swap.total - nodeData.swap.free) * constants.mb,
-        fred_read: fredOssRead,
-        fred_write: fredOssWrite,
-        fred_iops: fredMdsIops,
-        home_read: homeOssRead,
-        home_write: homeOssWrite,
-        home_iops: homeMdsIops,
-        apps_read: appsOssRead,
-        apps_iops: appsMdsIops,
-        images_read: imagesOssRead,
-        images_iops: imagesMdsIops,
-        jobfs_used: jobfs * constants.mb,
-        jobfs_requested: jobfsRequested * constants.mb,
-      };
+      // Create data point
+      const dataPoint = NodeDetails.createChartDataPoint(data, nodeData, jobMetrics);
 
-      if (nodeData.infiniband !== null) {
-        x.infiniband_in = nodeData.infiniband.bytes_in;
-        x.infiniband_out = nodeData.infiniband.bytes_out;
-        x.infiniband_pkts_in = nodeData.infiniband.pkts_in;
-        x.infiniband_pkts_out = nodeData.infiniband.pkts_out;
-      }
+      // Add optional node data
+      const finalDataPoint = NodeDetails.addOptionalDataToPoint(dataPoint, nodeData);
 
-      if (nodeData.lustre !== null) {
-        x.lustre_read = nodeData.lustre.read;
-        x.lustre_write = nodeData.lustre.write;
-      }
+      historyChart.push(finalDataPoint);
+    });
 
-      if (nodeData.jobfs !== null) {
-        x.jobfs_read = nodeData.jobfs.read;
-        x.jobfs_write = nodeData.jobfs.write;
-      }
-
-      for (let j = 0; j < nodeData.nGpus; j += 1) {
-        const gpuName = `gpu${j.toString()}`;
-        const gpuMemName = `${gpuName}_mem`;
-
-        if (nodeData.gpus && gpuName in nodeData.gpus) {
-          // Use GPU utilization from the data
-          x[gpuName] = nodeData.gpus[gpuName].util;
-
-          // Add GPU memory information
-          if (nodeData.gpus[gpuName].memory) {
-            const memTotal = nodeData.gpus[gpuName].memory.total;
-            const memUsed = nodeData.gpus[gpuName].memory.used;
-            // Convert MiB to bytes and store memory usage
-            if (memTotal > 0) {
-              // Convert from MiB to bytes
-              x[gpuMemName] = memUsed * constants.mb;
-              x[`${gpuMemName}_total`] = memTotal * constants.mb; // Store total for y-axis limit
-            }
-          }
-        }
-      }
-
-      historyChart.push(x);
-    }
     return historyChart;
   }
 
@@ -560,188 +779,6 @@ export default class NodeDetails extends React.Component {
           dataMax="dataMax"
           stacked={false}
         />
-      </div>
-    );
-  }
-
-  static getJobPropCharts(historyChart) {
-    const style = getComputedStyle(document.documentElement);
-
-    const charts = [];
-
-    charts.push(
-      <PropChart
-        key="cpu"
-        name="CPU"
-        data={historyChart}
-        dataKeys={["job_user", "job_system", "job_wait"]}
-        colors={[
-          style.getPropertyValue("--piecolor-user"),
-          style.getPropertyValue("--piecolor-system"),
-          style.getPropertyValue("--piecolor-wait"),
-        ]}
-        lineStyle={[
-          "fill",
-          "fill",
-        ]}
-        unit="%"
-        dataMax={100}
-        stacked
-      />,
-    );
-
-    charts.push(
-      <PropChart
-        key="mem"
-        name="Memory"
-        data={historyChart}
-        dataKeys={["job_mem", "job_mem_max", "job_mem_requested"]}
-        colors={[
-          style.getPropertyValue("--piecolor-mem"),
-          style.getPropertyValue("--piecolor-mem"),
-          style.getPropertyValue("--piecolor-mem"),
-        ]}
-        lineStyle={[
-          "fill",
-          "line",
-          "dashed",
-        ]}
-        unit="B"
-        stacked={false}
-      />,
-    );
-
-    charts.push(
-      <PropChart
-        key="job_lustre_read"
-        name="Lustre read"
-        data={historyChart}
-        dataKeys={["fred_read", "home_read", "apps_read", "images_read"]}
-        colors={[
-          style.getPropertyValue("--piecycle-1"),
-          style.getPropertyValue("--piecycle-2"),
-          style.getPropertyValue("--piecycle-3"),
-          style.getPropertyValue("--piecycle-4"),
-        ]}
-        lineStyle={[
-          "fill",
-          "fill",
-          "fill",
-          "fill",
-        ]}
-        unit="B/s"
-        stacked
-      />,
-    );
-
-    charts.push(
-      <PropChart
-        key="job_lustre_write"
-        name="Lustre write"
-        data={historyChart}
-        dataKeys={["fred_write", "home_write"]}
-        colors={[
-          style.getPropertyValue("--piecycle-1"),
-          style.getPropertyValue("--piecycle-2"),
-        ]}
-        lineStyle={[
-          "fill",
-          "fill",
-        ]}
-        unit="B/s"
-        stacked
-      />,
-    );
-
-    charts.push(
-      <PropChart
-        key="job_lustre_iops"
-        name="Lustre IOPS"
-        data={historyChart}
-        dataKeys={["fred_iops", "home_iops", "apps_iops", "images_iops"]}
-        colors={[
-          style.getPropertyValue("--piecycle-1"),
-          style.getPropertyValue("--piecycle-2"),
-          style.getPropertyValue("--piecycle-3"),
-          style.getPropertyValue("--piecycle-4"),
-        ]}
-        lineStyle={[
-          "fill",
-          "fill",
-          "fill",
-          "fill",
-        ]}
-        unit="/s"
-        stacked
-      />,
-    );
-
-    charts.push(
-      <PropChart
-        key="jobfs"
-        name="JOBFS usage"
-        data={historyChart}
-        dataKeys={["jobfs_used", "jobfs_requested"]}
-        colors={[
-          style.getPropertyValue("--piecycle-4"),
-          style.getPropertyValue("--piecycle-4"),
-        ]}
-        lineStyle={[
-          "fill",
-          "dashed",
-        ]}
-        unit="B"
-        stacked
-      />,
-    );
-
-    // Display a per-job GPU total if there are GPUs in this job
-    if (historyChart.length > 0 && historyChart[0].job_gpu >= 0) {
-      charts.push(
-        <PropChart
-          key="job_gpu"
-          name="GPU Utilization"
-          data={historyChart}
-          dataKeys={["job_gpu"]}
-          colors={[
-            style.getPropertyValue("--piecolor-gpu-1"),
-          ]}
-          lineStyle={[
-            "fill",
-          ]}
-          unit="%"
-          dataMax={100}
-          stacked
-        />,
-      );
-
-      // Display a per-job GPU memory usage if available
-      if (historyChart.length > 0 && historyChart[0].job_gpu_mem_total > 0) {
-        charts.push(
-          <PropChart
-            key="job_gpu_mem"
-            name="GPU Memory"
-            data={historyChart}
-            dataKeys={["job_gpu_mem"]}
-            colors={[
-              style.getPropertyValue("--piecolor-gpu-2"),
-            ]}
-            lineStyle={[
-              "fill",
-            ]}
-            unit="B"
-            dataMax={(historyChart[0].job_gpu_mem_total > 0)
-              ? historyChart[0].job_gpu_mem_total
-              : "dataMax"}
-            stacked={false}
-          />,
-        );
-      }
-    }
-
-    return (
-      <div className="prop-charts">
-        {charts}
       </div>
     );
   }

--- a/frontend/src/NodeDetails.jsx
+++ b/frontend/src/NodeDetails.jsx
@@ -235,6 +235,13 @@ export default class NodeDetails extends React.Component {
       // Only if the job has started running
       if (Object.prototype.hasOwnProperty.call(data.jobs, selectedJobId)) {
         const job = data.jobs[selectedJobId];
+
+        // Skip this data point if the job is not in RUNNING state
+        if (job.state !== "RUNNING") {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+
         const usage = getNodeUsage(selectedJobId, job, nodeData, name);
 
         // Memory usage


### PR DESCRIPTION
The graphs in the RHS pane would include timestamps from when the job was still pending. Aside from displaying incorrect data, this would cause errors with the logic for displaying GPU graphs.

Refactored functions for readability.